### PR TITLE
Pdet dependencies

### DIFF
--- a/bin/monte-carlo-vt
+++ b/bin/monte-carlo-vt
@@ -76,12 +76,15 @@ generator, timedistribution = montecarlo.path2generator(args.population)
 network = detector_cache.Network() # declare this shared reference here
 celest2geo = False
 for trans in generator._transforms:
+    if isinstance(trans, eventgen.SNR):
+        raise RuntimeError('please do not specify SNR within %s; this will be instantiated separately'%args.population)
     if isinstance(trans, eventgen.Pdet):
         raise RuntimeError('please do not specify Pdet within %s; this will be instantiated separately'%args.population)
     celest2geo += isinstance(trans, eventgen.Celestial2Geographic)
 if not celest2geo:
     generator.append_transform(eventgen.Celestial2Geographic())
-generator.append_transform(eventgen.Pdet(network, snr_thr=args.snr_threshold)) ### this must come after the rest of the transforms
+generator.append_transform(eventgen.SNR(network)) ### this must come after the rest of the transforms
+generator.append_transform(eventgen.Pdet(snr_thr=args.snr_threshold)) ### this must come after SNR
 
 #-------------------------------------------------
 

--- a/bin/streaming-monte-carlo-vt
+++ b/bin/streaming-monte-carlo-vt
@@ -125,12 +125,15 @@ generator, timedistribution = montecarlo.path2generator(args.population)
 network = detector_cache.Network() # declare this shared reference here
 celest2geo = False
 for trans in generator._transforms:
+    if isinstance(trans, eventgen.SNR):
+        raise RuntimeError('please do not specify SNR within %s; this will be instantiated separately'%args.population)
     if isinstance(trans, eventgen.Pdet):
         raise RuntimeError('please do not specify Pdet within %s; this will be instantiated separately'%args.population)
     celest2geo += isinstance(trans, eventgen.Celestial2Geographic)
 if not celest2geo:
     generator.append_transform(eventgen.Celestial2Geographic())
-generator.append_transform(eventgen.Pdet(network, snr_thr=args.snr_threshold)) ### this must come after the rest of the transforms
+generator.append_transform(eventgen.SNR(network)) ### this must come after the rest of the transforms
+generator.append_transform(eventgen.Pdet(snr_thr=args.snr_threshold)) ### this must come after SNR
 
 #-------------------------------------------------
 


### PR DESCRIPTION
updated how we automatically configure `gw_event_gen.eventgen.generators.MonteCarloIntegrator` objects within monte-carlo executables. This was required because `Pdet` now requires `SNR` to have been previously calculated for each event (requires `net_snr` to already be computed) so that we can quickly re-compute `pdet` with a different snr threshold without having to re-generate the waveforms for each sample.

There is an analogous change in `gw_event_gen` [here](https://git.ligo.org/chris-pankow/gw_event_gen/merge_requests/17).